### PR TITLE
Fix main/types resolving to invalid files

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "knex-schema-inspector",
   "version": "0.0.23",
   "description": "[WIP] Utility for extracting information about existing DB schema",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "dist/lib/index.js",
+  "types": "dist/lib/index.d.ts",
   "scripts": {
     "build": "tsc",
     "prepare": "npm run build",


### PR DESCRIPTION
This has caused the last few releases to not actually work, since locally cached content was packaged into the release, together with updated stuff, but the update stuff was not referenced.


see how the latest version contains both this file:
https://npm.runkit.com/knex-schema-inspector/dist/dialects/postgres.js?t=1604401589687
and this file:
https://npm.runkit.com/knex-schema-inspector/dist/lib/dialects/postgres.js?t=1604401589687

the one in dist/lib is actually updated, the other one is old.