### PR TITLE
Add enum fields in columnInfo

### DIFF
--- a/lib/dialects/postgres.ts
+++ b/lib/dialects/postgres.ts
@@ -14,6 +14,8 @@ type RawColumn = {
   table_name: string;
   table_schema: string;
   data_type: string;
+  udt_name: string;
+  enum_values: string;
   column_default: any | null;
   character_maximum_length: number | null;
   is_nullable: 'YES' | 'NO';
@@ -209,6 +211,14 @@ export default class Postgres implements SchemaInspector {
         'c.numeric_precision',
         'c.numeric_scale',
         'c.table_schema',
+        'c.udt_name',
+
+        knex
+          .select(knex.raw("string_agg(pg_catalog.pg_enum.enumlabel, '|')"))
+          .from('pg_enum')
+          .join('pg_type', 'pg_enum.enumtypid', '=', 'pg_type.oid')
+          .whereRaw('pg_type.typname = c.udt_name')
+          .as('enum_values'),
 
         knex
           .select(knex.raw(`'YES'`))
@@ -282,6 +292,10 @@ export default class Postgres implements SchemaInspector {
         name: rawColumn.column_name,
         table: rawColumn.table_name,
         type: rawColumn.data_type,
+        udt_name: rawColumn.udt_name,
+        enum_values: rawColumn.enum_values
+          ? rawColumn.enum_values.split('|')
+          : null,
         default_value: rawColumn.column_default
           ? this.parseDefaultValue(rawColumn.column_default)
           : null,
@@ -300,13 +314,14 @@ export default class Postgres implements SchemaInspector {
     }
 
     const records: RawColumn[] = await query;
-
     return records.map(
       (rawColumn): Column => {
         return {
           name: rawColumn.column_name,
           table: rawColumn.table_name,
           type: rawColumn.data_type,
+          udt_name: rawColumn.udt_name,
+          enum_values: (rawColumn.enum_values || '').split('|'),
           default_value: rawColumn.column_default
             ? this.parseDefaultValue(rawColumn.column_default)
             : null,

--- a/lib/dialects/postgres.ts
+++ b/lib/dialects/postgres.ts
@@ -85,6 +85,16 @@ export default class Postgres implements SchemaInspector {
     return Number(value);
   }
 
+  parseEnumValues(value: string) {
+    if (!value) return null;
+    const parts = value.split('|');
+    return parts.map((item) => {
+      const num = Number(item);
+      if (!Number.isNaN(num)) return num;
+      return item;
+    });
+  }
+
   // Tables
   // ===============================================================================================
 
@@ -293,9 +303,7 @@ export default class Postgres implements SchemaInspector {
         table: rawColumn.table_name,
         type: rawColumn.data_type,
         udt_name: rawColumn.udt_name,
-        enum_values: rawColumn.enum_values
-          ? rawColumn.enum_values.split('|')
-          : null,
+        enum_values: this.parseEnumValues(rawColumn.enum_values),
         default_value: rawColumn.column_default
           ? this.parseDefaultValue(rawColumn.column_default)
           : null,
@@ -321,7 +329,7 @@ export default class Postgres implements SchemaInspector {
           table: rawColumn.table_name,
           type: rawColumn.data_type,
           udt_name: rawColumn.udt_name,
-          enum_values: (rawColumn.enum_values || '').split('|'),
+          enum_values: this.parseEnumValues(rawColumn.enum_values),
           default_value: rawColumn.column_default
             ? this.parseDefaultValue(rawColumn.column_default)
             : null,

--- a/lib/types/column.ts
+++ b/lib/types/column.ts
@@ -3,7 +3,7 @@ export interface Column {
   table: string;
   type: string;
   udt_name?: string;
-  enum_values?: Array<string | number>;
+  enum_values?: Array<string | number> | null;
   default_value: any | null;
   max_length: number | null;
   precision: number | null;

--- a/lib/types/column.ts
+++ b/lib/types/column.ts
@@ -2,6 +2,8 @@ export interface Column {
   name: string;
   table: string;
   type: string;
+  udt_name?: string;
+  enum_values?: Array<string | number>;
   default_value: any | null;
   max_length: number | null;
   precision: number | null;


### PR DESCRIPTION
I need to get possible enum values for given column. 

This PR extends `inspector.columnInfo('table')` with
- `udt_name` - user defined type. For enums this will return enum name, for other types it will return type name eg. `varchar`
- `enum_values` - if column is enum then this will be an array of possible values

Example result for `inspector.columnInfo('user', 'role')`:

```
{ 
    name: 'role',
    table: 'user',
    type: 'USER-DEFINED',
    udt_name: 'user_role_enum', // NEW
    enum_values: [ 0, 1 ], // NEW
    default_value: 0,
    max_length: null,
    precision: null,
    scale: null,
    is_nullable: true,
    is_primary_key: false,
    has_auto_increment: false,
    foreign_key_column: null,
    foreign_key_table: null,
    comment: null,
    schema: 'public',
    foreign_key_schema: null 
}
```

TODO:
- [x] PostgreSQL
- [ ] MySQL
- [ ] MSSQL
- [ ] OracleDB
- [ ] SQLite