### PR TITLE
Add DISTINCT clause in foreignKeys query

### DIFF
--- a/lib/dialects/mysql.ts
+++ b/lib/dialects/mysql.ts
@@ -291,7 +291,7 @@ export default class MySQL implements SchemaInspector {
   async foreignKeys(table?: string) {
     const result = await this.knex.raw<[ForeignKey[]]>(
       `
-      SELECT
+      SELECT DISTINCT
         rc.TABLE_NAME AS 'table',
         kcu.COLUMN_NAME AS 'column',
         rc.REFERENCED_TABLE_NAME AS 'foreign_key_table',


### PR DESCRIPTION
Handles a situation in which MySQL 8.0.25 returns not distinct results. This issue was not observed in version 8.0.19.