### PR TITLE
[Oracle] Added fix for inspector returning internal SYS columns 

### DIFF
--- a/lib/dialects/oracledb.ts
+++ b/lib/dialects/oracledb.ts
@@ -108,7 +108,7 @@ export default class oracleDB implements SchemaInspector {
         'COLUMN_NAME as column'
       )
       .from('USER_TAB_COLS')
-      .whereNot({ HIDDEN_COLUMN: 'YES' });
+      .where({ HIDDEN_COLUMN: 'NO' });
 
     if (table) {
       query.andWhere({ TABLE_NAME: table });
@@ -165,7 +165,7 @@ export default class oracleDB implements SchemaInspector {
         'c.COLUMN_NAME': 'ct.COLUMN_NAME',
       })
       .leftJoin('uc as fk', 'ct.R_CONSTRAINT_NAME', 'fk.CONSTRAINT_NAME')
-      .whereNot({ 'c.HIDDEN_COLUMN': 'YES' });
+      .where({ 'c.HIDDEN_COLUMN': 'NO' });
 
     if (table) {
       query.andWhere({ 'c.TABLE_NAME': table });
@@ -197,8 +197,8 @@ export default class oracleDB implements SchemaInspector {
       .where({
         TABLE_NAME: table,
         COLUMN_NAME: column,
+        HIDDEN_COLUMN: 'NO',
       })
-      .andWhereNot({ HIDDEN_COLUMN: 'YES' })
       .first();
     return !!result?.count;
   }

--- a/lib/dialects/oracledb.ts
+++ b/lib/dialects/oracledb.ts
@@ -107,10 +107,11 @@ export default class oracleDB implements SchemaInspector {
         'TABLE_NAME as table',
         'COLUMN_NAME as column'
       )
-      .from('USER_TAB_COLS');
+      .from('USER_TAB_COLS')
+      .whereNot({ HIDDEN_COLUMN: 'YES' });
 
     if (table) {
-      query.where({ TABLE_NAME: table });
+      query.andWhere({ TABLE_NAME: table });
     }
 
     return await query;
@@ -163,10 +164,11 @@ export default class oracleDB implements SchemaInspector {
         'c.TABLE_NAME': 'ct.TABLE_NAME',
         'c.COLUMN_NAME': 'ct.COLUMN_NAME',
       })
-      .leftJoin('uc as fk', 'ct.R_CONSTRAINT_NAME', 'fk.CONSTRAINT_NAME');
+      .leftJoin('uc as fk', 'ct.R_CONSTRAINT_NAME', 'fk.CONSTRAINT_NAME')
+      .whereNot({ 'c.HIDDEN_COLUMN': 'YES' });
 
     if (table) {
-      query.where({ 'c.TABLE_NAME': table });
+      query.andWhere({ 'c.TABLE_NAME': table });
     }
 
     if (column) {
@@ -196,6 +198,7 @@ export default class oracleDB implements SchemaInspector {
         TABLE_NAME: table,
         COLUMN_NAME: column,
       })
+      .andWhereNot({ HIDDEN_COLUMN: 'YES' })
       .first();
     return !!result?.count;
   }


### PR DESCRIPTION
`DBA_TAB_COLS` can contain internal system columns which shouldn't be returned. We can filter these by `HIDDEN_COLUMN = 'YES'`. Issue described more here:

https://stackoverflow.com/questions/45756882/why-does-oracle-add-a-hidden-column-here/45907226