### PR TITLE
Cleaned up Oracle duplicate index handling

### DIFF
--- a/lib/dialects/oracledb.ts
+++ b/lib/dialects/oracledb.ts
@@ -132,23 +132,22 @@ export default class oracleDB implements SchemaInspector {
       .with(
         'uc',
         this.knex.raw(`
-          SELECT /*+ materialize */
+          SELECT /*+ materialize */ DISTINCT
             "uc"."TABLE_NAME",
             "ucc"."COLUMN_NAME",
             "uc"."CONSTRAINT_NAME",
             "uc"."CONSTRAINT_TYPE",
-            "uc"."R_CONSTRAINT_NAME"
+            "uc"."R_CONSTRAINT_NAME",
+            COUNT(*) OVER(
+              PARTITION BY "uc"."CONSTRAINT_NAME"
+            ) "CONSTRAINT_COUNT",
+            ROW_NUMBER() OVER(
+              PARTITION BY "uc"."TABLE_NAME", "ucc"."COLUMN_NAME" ORDER BY "uc"."CONSTRAINT_TYPE"
+            ) "CONSTRAINT_PRIORITY"
           FROM "USER_CONSTRAINTS" "uc"
-          INNER JOIN (
-            SELECT
-              "COLUMN_NAME",
-              "CONSTRAINT_NAME",
-              COUNT(*) OVER(PARTITION BY "CONSTRAINT_NAME") "INDEX_COLUMN_COUNT"
-            FROM "USER_CONS_COLUMNS"
-          ) "ucc"
+          INNER JOIN "USER_CONS_COLUMNS" "ucc"
             ON "uc"."CONSTRAINT_NAME" = "ucc"."CONSTRAINT_NAME"
             AND "uc"."CONSTRAINT_TYPE" IN ('P', 'U', 'R')
-            AND "ucc"."INDEX_COLUMN_COUNT" = 1
         `)
       )
       .select<RawColumn[]>(
@@ -163,9 +162,7 @@ export default class oracleDB implements SchemaInspector {
         'c.IDENTITY_COLUMN',
         'c.VIRTUAL_COLUMN',
         'cm.COMMENTS as COLUMN_COMMENT',
-        this.knex.raw(
-          'COALESCE("ct"."CONSTRAINT_TYPE", "uct"."CONSTRAINT_TYPE") AS "CONSTRAINT_TYPE"'
-        ),
+        'ct.CONSTRAINT_TYPE',
         'fk.TABLE_NAME as REFERENCED_TABLE_NAME',
         'fk.COLUMN_NAME as REFERENCED_COLUMN_NAME'
       )
@@ -174,18 +171,12 @@ export default class oracleDB implements SchemaInspector {
         'c.TABLE_NAME': 'cm.TABLE_NAME',
         'c.COLUMN_NAME': 'cm.COLUMN_NAME',
       })
-      .joinRaw(
-        `LEFT JOIN "uc" "ct"
-          ON "c"."TABLE_NAME" = "ct"."TABLE_NAME"
-          AND "c"."COLUMN_NAME" = "ct"."COLUMN_NAME"
-          AND "ct"."CONSTRAINT_TYPE" != 'U'`
-      )
-      .joinRaw(
-        `LEFT JOIN "uc" "uct"
-          ON "c"."TABLE_NAME" = "uct"."TABLE_NAME"
-          AND "c"."COLUMN_NAME" = "uct"."COLUMN_NAME"
-          AND "uct"."CONSTRAINT_TYPE" = 'U'`
-      )
+      .leftJoin('uc as ct', {
+        'c.TABLE_NAME': 'ct.TABLE_NAME',
+        'c.COLUMN_NAME': 'ct.COLUMN_NAME',
+        'ct.CONSTRAINT_COUNT': this.knex.raw('1'),
+        'ct.CONSTRAINT_PRIORITY': this.knex.raw('1'),
+      })
       .leftJoin('uc as fk', 'ct.R_CONSTRAINT_NAME', 'fk.CONSTRAINT_NAME')
       .where({ 'c.HIDDEN_COLUMN': 'NO' });
 

--- a/lib/dialects/oracledb.ts
+++ b/lib/dialects/oracledb.ts
@@ -174,8 +174,8 @@ export default class oracleDB implements SchemaInspector {
       .leftJoin('uc as ct', {
         'c.TABLE_NAME': 'ct.TABLE_NAME',
         'c.COLUMN_NAME': 'ct.COLUMN_NAME',
-        'ct.CONSTRAINT_COUNT': this.knex.raw('1'),
-        'ct.CONSTRAINT_PRIORITY': this.knex.raw('1'),
+        'ct.CONSTRAINT_COUNT': 1,
+        'ct.CONSTRAINT_PRIORITY': 1,
       })
       .leftJoin('uc as fk', 'ct.R_CONSTRAINT_NAME', 'fk.CONSTRAINT_NAME')
       .where({ 'c.HIDDEN_COLUMN': 'NO' });

--- a/lib/dialects/oracledb.ts
+++ b/lib/dialects/oracledb.ts
@@ -132,7 +132,7 @@ export default class oracleDB implements SchemaInspector {
       .with(
         'uc',
         this.knex.raw(`
-          SELECT /*+ materialize */ DISTINCT
+          SELECT /*+ materialize */
             "uc"."TABLE_NAME",
             "ucc"."COLUMN_NAME",
             "uc"."CONSTRAINT_NAME",


### PR DESCRIPTION
Removed some unnecessary complexity from the Oracle index handling. We can calculate the constraint priority in the with clause and use it in the main query.