### PR TITLE
Prevent crashing on internal seq tables

### DIFF
--- a/lib/dialects/postgres.ts
+++ b/lib/dialects/postgres.ts
@@ -302,6 +302,7 @@ export default class Postgres implements SchemaInspector {
       `
       )
       .whereIn('c.table_schema', this.explodedSchema)
+      .andWhere('pg_class.relkind', '!=', 'S')
       .orderBy(['c.table_name', 'c.ordinal_position']);
 
     if (table) {

--- a/test/seed/cockroachdb.sql
+++ b/test/seed/cockroachdb.sql
@@ -9,6 +9,7 @@ create table teams (
   activated_at date,
   unique(uuid)
 );
+
 comment on column teams.credits is 'Remaining usage credits';
 
 create table users (


### PR DESCRIPTION
When using `SET serial_normalization = "sql_sequence"` in CockroachDB, the `_seq` tables where read as actual tables, causing some methods to crash.