### PR TITLE
Rework PG to use (way faster) pg_catalog

### DIFF
--- a/lib/dialects/cockroachdb.ts
+++ b/lib/dialects/cockroachdb.ts
@@ -2,7 +2,65 @@ import { Knex } from 'knex';
 import { SchemaInspector } from '../types/schema-inspector';
 import { Table } from '../types/table';
 import { Column } from '../types/column';
+import { ForeignKey } from '../types/foreign-key';
+import { stripQuotes } from '../utils/strip-quotes';
 import isNil from 'lodash.isnil';
+
+type RawTable = {
+  table_name: string;
+  table_schema: 'public' | string;
+  table_comment: string | null;
+};
+
+type RawColumn = {
+  column_name: string;
+  table_name: string;
+  table_schema: string;
+  data_type: string;
+  column_default: any | null;
+  character_maximum_length: null | number | string;
+  is_generated: 'NEVER' | 'ALWAYS';
+  is_nullable: 'YES' | 'NO';
+  is_unique: boolean;
+  is_primary: boolean;
+  is_identity: 'YES' | 'NO';
+  generation_expression: null | string;
+  numeric_precision: null | number | string;
+  numeric_scale: null | number | string;
+  serial: null | string;
+  column_comment: string | null;
+  foreign_key_schema: null | string;
+  foreign_key_table: null | string;
+  foreign_key_column: null | string;
+};
+
+function convertStringOrNumber(t: string | number | null): number | null {
+  return t == undefined ? t : Number(t);
+}
+
+export function rawColumnToColumn(rawColumn: RawColumn): Column {
+  return {
+    name: rawColumn.column_name,
+    table: rawColumn.table_name,
+    data_type: rawColumn.data_type,
+    default_value: parseDefaultValue(rawColumn.column_default),
+    generation_expression: rawColumn.generation_expression || null,
+    max_length: convertStringOrNumber(rawColumn.character_maximum_length),
+    numeric_precision: convertStringOrNumber(rawColumn.numeric_precision),
+    numeric_scale: convertStringOrNumber(rawColumn.numeric_scale),
+    is_generated: rawColumn.is_generated === 'ALWAYS',
+    is_nullable: rawColumn.is_nullable === 'YES',
+    is_unique: rawColumn.is_unique,
+    is_primary_key: rawColumn.is_primary,
+    has_auto_increment:
+      rawColumn.serial !== null || rawColumn.is_identity === 'YES',
+    comment: rawColumn.column_comment,
+    schema: rawColumn.table_schema,
+    foreign_key_schema: rawColumn.foreign_key_schema,
+    foreign_key_table: rawColumn.foreign_key_table,
+    foreign_key_column: rawColumn.foreign_key_column,
+  };
+}
 
 /**
  * Converts CockroachDB default value to JS
@@ -26,14 +84,10 @@ export default class CockroachDB implements SchemaInspector {
   knex: Knex;
   schema: string;
   explodedSchema: string[];
-  database: string;
 
   constructor(knex: Knex) {
     this.knex = knex;
-    this.database = this.knex.client.config.database;
-
     const config = knex.client.config;
-
     if (!config.searchPath) {
       this.schema = 'public';
       this.explodedSchema = [this.schema];
@@ -65,7 +119,11 @@ export default class CockroachDB implements SchemaInspector {
    * List all existing tables in the current schema/database
    */
   async tables() {
-    console.log(this.knex.client);
+    const records = await this.knex
+      .select<{ tablename: string }[]>('tablename')
+      .from('pg_catalog.pg_tables')
+      .whereIn('schemaname', this.explodedSchema);
+    return records.map(({ tablename }) => tablename);
   }
 
   /**
@@ -74,12 +132,62 @@ export default class CockroachDB implements SchemaInspector {
    */
   tableInfo(): Promise<Table[]>;
   tableInfo(table: string): Promise<Table>;
-  async tableInfo(table?: string) {}
+  async tableInfo(table?: string) {
+    const query = this.knex
+      .select(
+        'table_name',
+        'table_schema',
+        this.knex
+          .select(this.knex.raw('obj_description(oid)'))
+          .from('pg_class')
+          .where({ relkind: 'r' })
+          .andWhere({ relname: 'table_name' })
+          .as('table_comment')
+      )
+      .from('information_schema.tables')
+      .whereIn('table_schema', this.explodedSchema)
+      .andWhereRaw(`"table_catalog" = current_database()`)
+      .andWhere({ table_type: 'BASE TABLE' })
+      .orderBy('table_name', 'asc');
+
+    if (table) {
+      const rawTable: RawTable = await query
+        .andWhere({ table_name: table })
+        .limit(1)
+        .first();
+
+      return {
+        name: rawTable.table_name,
+        schema: rawTable.table_schema,
+        comment: rawTable.table_comment,
+      } as Table;
+    }
+
+    const records = await query;
+
+    return records.map((rawTable: RawTable): Table => {
+      return {
+        name: rawTable.table_name,
+        schema: rawTable.table_schema,
+        comment: rawTable.table_comment,
+      };
+    });
+  }
 
   /**
    * Check if a table exists in the current schema/database
    */
-  async hasTable(table: string) {}
+  async hasTable(table: string) {
+    const subquery = this.knex
+      .select()
+      .from('information_schema.tables')
+      .whereIn('table_schema', this.explodedSchema)
+      .andWhere({ table_name: table });
+    const record = await this.knex
+      .select<{ exists: boolean }>(this.knex.raw('exists (?)', [subquery]))
+      .first();
+    return record?.exists || false;
+  }
 
   // Columns
   // ===============================================================================================
@@ -87,7 +195,26 @@ export default class CockroachDB implements SchemaInspector {
   /**
    * Get all the available columns in the current schema/database. Can be filtered to a specific table
    */
-  async columns(table?: string) {}
+  async columns(table?: string) {
+    const query = this.knex
+      .select<{ table_name: string; column_name: string }[]>(
+        'table_name',
+        'column_name'
+      )
+      .from('information_schema.columns')
+      .whereIn('table_schema', this.explodedSchema);
+
+    if (table) {
+      query.andWhere({ table_name: table });
+    }
+
+    const records = await query;
+
+    return records.map(({ table_name, column_name }) => ({
+      table: table_name,
+      column: column_name,
+    }));
+  }
 
   /**
    * Get the column info for all columns, columns in a given table, or a specific column.
@@ -95,19 +222,250 @@ export default class CockroachDB implements SchemaInspector {
   columnInfo(): Promise<Column[]>;
   columnInfo(table: string): Promise<Column[]>;
   columnInfo(table: string, column: string): Promise<Column>;
-  async columnInfo<T>(table?: string, column?: string) {}
+  async columnInfo<T>(table?: string, column?: string) {
+    const { knex } = this;
+
+    const query = knex
+      .select(
+        'c.column_name',
+        'c.table_name',
+        'c.data_type',
+        'c.column_default',
+        'c.character_maximum_length',
+        'c.is_generated',
+        'c.is_nullable',
+        'c.numeric_precision',
+        'c.numeric_scale',
+        'c.table_schema',
+        'c.is_identity',
+        'c.generation_expression',
+
+        knex.raw(
+          'pg_get_serial_sequence(quote_ident(c.table_name), c.column_name) as serial'
+        ),
+
+        knex.raw(
+          'pg_catalog.col_description(pg_class.oid, c.ordinal_position:: int) as column_comment'
+        ),
+
+        knex.raw(`COALESCE(pg.indisunique, false) as is_unique`),
+        knex.raw(`COALESCE(pg.indisprimary, false) as is_primary`),
+
+        'ffk.foreign_key_schema',
+        'ffk.foreign_key_table',
+        'ffk.foreign_key_column'
+      )
+      .from(knex.raw('information_schema.columns c'))
+      .joinRaw(
+        `
+        LEFT JOIN pg_catalog.pg_class
+          ON pg_catalog.pg_class.oid = CONCAT_WS('.', quote_ident(c.table_schema), quote_ident(c.table_name)):: regclass:: oid
+          AND pg_catalog.pg_class.relname = c.table_name
+      `
+      )
+      .joinRaw(
+        `
+        LEFT JOIN LATERAL (
+          SELECT
+            pg_index.indisprimary,
+            pg_index.indisunique
+          FROM pg_index
+          JOIN pg_attribute
+            ON pg_attribute.attrelid = pg_index.indrelid
+            AND pg_attribute.attnum = any(pg_index.indkey)
+          WHERE pg_index.indrelid = quote_ident(c.table_name)::regclass
+          AND pg_attribute.attname = c.column_name
+          AND pg_index.indnatts = 1
+          LIMIT 1
+        ) pg ON true
+      `
+      )
+      .joinRaw(
+        `
+        LEFT JOIN LATERAL (
+          SELECT
+            k2.table_schema AS foreign_key_schema,
+            k2.table_name AS foreign_key_table,
+            k2.column_name AS foreign_key_column
+          FROM
+            information_schema.key_column_usage k1
+            JOIN information_schema.referential_constraints fk using (
+              constraint_schema, constraint_name
+            )
+            JOIN information_schema.key_column_usage k2
+              ON k2.constraint_schema = fk.unique_constraint_schema
+              AND k2.constraint_name = fk.unique_constraint_name
+              AND k2.ordinal_position = k1.position_in_unique_constraint
+            WHERE k1.table_name = c.table_name
+            AND k1.column_name = c.column_name
+        ) ffk ON TRUE
+      `
+      )
+      .whereIn('c.table_schema', this.explodedSchema)
+      .andWhere('pg_class.relkind', '!=', 'S')
+      .orderBy(['c.table_name', 'c.ordinal_position']);
+
+    if (table) {
+      query.andWhere({ 'c.table_name': table });
+    }
+
+    if (column) {
+      const rawColumn = await query
+        .andWhere({ 'c.column_name': column })
+        .first();
+
+      return rawColumnToColumn(rawColumn);
+    }
+
+    const records: RawColumn[] = await query;
+
+    return records.map(rawColumnToColumn);
+  }
 
   /**
    * Check if the given table contains the given column
    */
-  async hasColumn(table: string, column: string) {}
+  async hasColumn(table: string, column: string) {
+    const subquery = this.knex
+      .select()
+      .from('information_schema.columns')
+      .whereIn('table_schema', this.explodedSchema)
+      .andWhere({
+        table_name: table,
+        column_name: column,
+      });
+    const record = await this.knex
+      .select<{ exists: boolean }>(this.knex.raw('exists (?)', [subquery]))
+      .first();
+    return record?.exists || false;
+  }
 
   /**
    * Get the primary key column for the given table
    */
-  async primary(table: string): Promise<string | null> {}
+  async primary(table: string): Promise<string> {
+    const result = await this.knex
+      .select('information_schema.key_column_usage.column_name')
+      .from('information_schema.key_column_usage')
+      .leftJoin(
+        'information_schema.table_constraints',
+        'information_schema.table_constraints.constraint_name',
+        'information_schema.key_column_usage.constraint_name'
+      )
+      .whereIn(
+        'information_schema.table_constraints.table_schema',
+        this.explodedSchema
+      )
+      .andWhere({
+        'information_schema.table_constraints.constraint_type': 'PRIMARY KEY',
+        'information_schema.table_constraints.table_name': table,
+      })
+      .first();
+
+    return result ? result.column_name : null;
+  }
 
   // Foreign Keys
   // ===============================================================================================
-  async foreignKeys(table?: string) {}
+
+  async foreignKeys(table?: string) {
+    const result = await this.knex.raw<{ rows: ForeignKey[] }>(`
+      SELECT
+        c.conrelid::regclass::text AS "table",
+        (
+          SELECT
+            STRING_AGG(a.attname, ','
+            ORDER BY
+              t.seq)
+          FROM (
+            SELECT
+              ROW_NUMBER() OVER (ROWS UNBOUNDED PRECEDING) AS seq,
+              attnum
+            FROM
+              UNNEST(c.conkey) AS t (attnum)) AS t
+          INNER JOIN pg_attribute AS a ON a.attrelid = c.conrelid
+            AND a.attnum = t.attnum) AS "column",
+        tt.name AS foreign_key_table,
+        (
+          SELECT
+            STRING_AGG(QUOTE_IDENT(a.attname), ','
+            ORDER BY
+              t.seq)
+          FROM (
+            SELECT
+              ROW_NUMBER() OVER (ROWS UNBOUNDED PRECEDING) AS seq,
+              attnum
+            FROM
+              UNNEST(c.confkey) AS t (attnum)) AS t
+        INNER JOIN pg_attribute AS a ON a.attrelid = c.confrelid
+          AND a.attnum = t.attnum) AS foreign_key_column,
+        tt.schema AS foreign_key_schema,
+        c.conname AS constraint_name,
+        CASE confupdtype
+        WHEN 'r' THEN
+          'RESTRICT'
+        WHEN 'c' THEN
+          'CASCADE'
+        WHEN 'n' THEN
+          'SET NULL'
+        WHEN 'd' THEN
+          'SET DEFAULT'
+        WHEN 'a' THEN
+          'NO ACTION'
+        ELSE
+          NULL
+        END AS on_update,
+        CASE confdeltype
+        WHEN 'r' THEN
+          'RESTRICT'
+        WHEN 'c' THEN
+          'CASCADE'
+        WHEN 'n' THEN
+          'SET NULL'
+        WHEN 'd' THEN
+          'SET DEFAULT'
+        WHEN 'a' THEN
+          'NO ACTION'
+        ELSE
+          NULL
+        END AS
+        on_delete
+      FROM
+        pg_catalog.pg_constraint AS c
+        INNER JOIN (
+          SELECT
+            pg_class.oid,
+            QUOTE_IDENT(pg_namespace.nspname) AS SCHEMA,
+            QUOTE_IDENT(pg_class.relname) AS name
+          FROM
+            pg_class
+            INNER JOIN pg_namespace ON pg_class.relnamespace = pg_namespace.oid) AS tf ON tf.oid = c.conrelid
+        INNER JOIN (
+          SELECT
+            pg_class.oid,
+            QUOTE_IDENT(pg_namespace.nspname) AS SCHEMA,
+            QUOTE_IDENT(pg_class.relname) AS name
+          FROM
+            pg_class
+            INNER JOIN pg_namespace ON pg_class.relnamespace = pg_namespace.oid) AS tt ON tt.oid = c.confrelid
+      WHERE
+        c.contype = 'f';
+    `);
+
+    const rowsWithoutQuotes = result.rows.map(stripRowQuotes);
+
+    if (table) {
+      return rowsWithoutQuotes.filter((row) => row.table === table);
+    }
+
+    return rowsWithoutQuotes;
+
+    function stripRowQuotes(row: ForeignKey): ForeignKey {
+      return Object.fromEntries(
+        Object.entries(row).map(([key, value]) => {
+          return [key, stripQuotes(value)];
+        })
+      ) as ForeignKey;
+    }
+  }
 }

--- a/lib/dialects/cockroachdb.ts
+++ b/lib/dialects/cockroachdb.ts
@@ -1,1 +1,113 @@
-export { parseDefaultValue, default as CockroachDB, default } from './postgres';
+import { Knex } from 'knex';
+import { SchemaInspector } from '../types/schema-inspector';
+import { Table } from '../types/table';
+import { Column } from '../types/column';
+import isNil from 'lodash.isnil';
+
+/**
+ * Converts CockroachDB default value to JS
+ * Eg `'example'::character varying` => `example`
+ */
+export function parseDefaultValue(type: string | null) {
+  if (isNil(type)) return null;
+  if (type.startsWith('nextval(')) return type;
+
+  let [value, cast] = type.split('::');
+
+  value = value.replace(/^\'([\s\S]*)\'$/, '$1');
+
+  if (/.*json.*/.test(cast)) return JSON.parse(value);
+  if (/.*(char|text).*/.test(cast)) return String(value);
+
+  return isNaN(value as any) ? value : Number(value);
+}
+
+export default class CockroachDB implements SchemaInspector {
+  knex: Knex;
+  schema: string;
+  explodedSchema: string[];
+  database: string;
+
+  constructor(knex: Knex) {
+    this.knex = knex;
+    this.database = this.knex.client.config.database;
+
+    const config = knex.client.config;
+
+    if (!config.searchPath) {
+      this.schema = 'public';
+      this.explodedSchema = [this.schema];
+    } else if (typeof config.searchPath === 'string') {
+      this.schema = config.searchPath;
+      this.explodedSchema = [config.searchPath];
+    } else {
+      this.schema = config.searchPath[0];
+      this.explodedSchema = config.searchPath;
+    }
+  }
+
+  // CockroachDB specific
+  // ===============================================================================================
+
+  /**
+   * Set the schema to be used in other methods
+   */
+  withSchema(schema: string) {
+    this.schema = schema;
+    this.explodedSchema = [this.schema];
+    return this;
+  }
+
+  // Tables
+  // ===============================================================================================
+
+  /**
+   * List all existing tables in the current schema/database
+   */
+  async tables() {
+    console.log(this.knex.client);
+  }
+
+  /**
+   * Get the table info for a given table. If table parameter is undefined, it will return all tables
+   * in the current schema/database
+   */
+  tableInfo(): Promise<Table[]>;
+  tableInfo(table: string): Promise<Table>;
+  async tableInfo(table?: string) {}
+
+  /**
+   * Check if a table exists in the current schema/database
+   */
+  async hasTable(table: string) {}
+
+  // Columns
+  // ===============================================================================================
+
+  /**
+   * Get all the available columns in the current schema/database. Can be filtered to a specific table
+   */
+  async columns(table?: string) {}
+
+  /**
+   * Get the column info for all columns, columns in a given table, or a specific column.
+   */
+  columnInfo(): Promise<Column[]>;
+  columnInfo(table: string): Promise<Column[]>;
+  columnInfo(table: string, column: string): Promise<Column>;
+  async columnInfo<T>(table?: string, column?: string) {}
+
+  /**
+   * Check if the given table contains the given column
+   */
+  async hasColumn(table: string, column: string) {}
+
+  /**
+   * Get the primary key column for the given table
+   */
+  async primary(table: string): Promise<string | null> {}
+
+  // Foreign Keys
+  // ===============================================================================================
+  async foreignKeys(table?: string) {}
+}

--- a/lib/dialects/cockroachdb.ts
+++ b/lib/dialects/cockroachdb.ts
@@ -1,6 +1,1 @@
-export {
-  rawColumnToColumn,
-  parseDefaultValue,
-  default as CockroachDB,
-  default,
-} from './postgres';
+export { parseDefaultValue, default as CockroachDB, default } from './postgres';

--- a/lib/dialects/postgres.ts
+++ b/lib/dialects/postgres.ts
@@ -284,12 +284,8 @@ export default class Postgres implements SchemaInspector {
           frel.relnamespace::regnamespace::text AS foreign_key_schema,
           frel.relname AS foreign_key_table,
           fatt.attname AS foreign_key_column,
-          CASE con.contype
-            WHEN 'p' THEN
-              CASE 
-                WHEN pg_get_serial_sequence(quote_ident(rel.relname), att.attname) != '' THEN TRUE
-                ELSE FALSE
-              END
+          CASE
+            WHEN con.contype = 'p' THEN pg_get_serial_sequence(att.attrelid::regclass::text, att.attname) != ''
             ELSE NULL
           END AS has_auto_increment
         FROM

--- a/test/cockroachdb.spec.ts
+++ b/test/cockroachdb.spec.ts
@@ -130,7 +130,7 @@ describe('cockroachdb-no-search-path', () => {
         {
           name: 'primaryKey',
           table: 'camelCase',
-          data_type: 'int8',
+          data_type: 'bigint',
           default_value: 'unique_rowid()',
           max_length: null,
           numeric_precision: 64,
@@ -149,7 +149,7 @@ describe('cockroachdb-no-search-path', () => {
         },
         {
           comment: null,
-          data_type: 'int8',
+          data_type: 'bigint',
           default_value: 'unique_rowid()',
           foreign_key_column: null,
           foreign_key_schema: null,
@@ -169,7 +169,7 @@ describe('cockroachdb-no-search-path', () => {
         },
         {
           comment: null,
-          data_type: 'int8',
+          data_type: 'bigint',
           default_value: null,
           foreign_key_column: 'primaryKey',
           foreign_key_schema: 'public',
@@ -189,7 +189,7 @@ describe('cockroachdb-no-search-path', () => {
         },
         {
           comment: null,
-          data_type: 'int8',
+          data_type: 'bigint',
           default_value: null,
           foreign_key_column: 'id',
           foreign_key_schema: 'public',
@@ -250,7 +250,7 @@ describe('cockroachdb-no-search-path', () => {
         {
           name: 'created_at',
           table: 'page_visits',
-          data_type: 'timestamp',
+          data_type: 'timestamp without time zone',
           default_value: null,
           max_length: null,
           numeric_precision: null,
@@ -270,7 +270,7 @@ describe('cockroachdb-no-search-path', () => {
         {
           name: 'id',
           table: 'teams',
-          data_type: 'int8',
+          data_type: 'bigint',
           default_value: 'unique_rowid()',
           max_length: null,
           numeric_precision: 64,
@@ -290,7 +290,7 @@ describe('cockroachdb-no-search-path', () => {
         {
           name: 'uuid',
           table: 'teams',
-          data_type: 'bpchar',
+          data_type: 'character',
           default_value: null,
           max_length: 36,
           numeric_precision: null,
@@ -370,7 +370,7 @@ describe('cockroachdb-no-search-path', () => {
         {
           name: 'credits',
           table: 'teams',
-          data_type: 'int8',
+          data_type: 'bigint',
           default_value: null,
           max_length: null,
           numeric_precision: 64,
@@ -390,7 +390,7 @@ describe('cockroachdb-no-search-path', () => {
         {
           name: 'created_at',
           table: 'teams',
-          data_type: 'timestamp',
+          data_type: 'timestamp without time zone',
           default_value: null,
           max_length: null,
           numeric_precision: null,
@@ -430,7 +430,7 @@ describe('cockroachdb-no-search-path', () => {
         {
           name: 'id',
           table: 'users',
-          data_type: 'int8',
+          data_type: 'bigint',
           default_value: 'unique_rowid()',
           max_length: null,
           numeric_precision: 64,
@@ -450,7 +450,7 @@ describe('cockroachdb-no-search-path', () => {
         {
           name: 'team_id',
           table: 'users',
-          data_type: 'int8',
+          data_type: 'bigint',
           default_value: null,
           max_length: null,
           numeric_precision: 64,
@@ -535,7 +535,7 @@ describe('cockroachdb-no-search-path', () => {
         {
           name: 'id',
           table: 'teams',
-          data_type: 'int8',
+          data_type: 'bigint',
           default_value: 'unique_rowid()',
           max_length: null,
           numeric_precision: 64,
@@ -555,7 +555,7 @@ describe('cockroachdb-no-search-path', () => {
         {
           name: 'uuid',
           table: 'teams',
-          data_type: 'bpchar',
+          data_type: 'character',
           default_value: null,
           max_length: 36,
           numeric_precision: null,
@@ -575,7 +575,7 @@ describe('cockroachdb-no-search-path', () => {
         {
           name: 'name',
           table: 'teams',
-          data_type: 'varchar',
+          data_type: 'character varying',
           default_value: null,
           max_length: 100,
           numeric_precision: null,
@@ -595,12 +595,12 @@ describe('cockroachdb-no-search-path', () => {
         {
           name: 'name_upper',
           table: 'teams',
-          data_type: 'varchar',
+          data_type: 'character varying',
           default_value: null,
           max_length: 100,
           numeric_precision: null,
           numeric_scale: null,
-          is_generated: true,
+          is_generated: false,
           generation_expression: 'upper(name)',
           is_nullable: true,
           is_unique: false,
@@ -635,7 +635,7 @@ describe('cockroachdb-no-search-path', () => {
         {
           name: 'credits',
           table: 'teams',
-          data_type: 'int8',
+          data_type: 'bigint',
           default_value: null,
           max_length: null,
           numeric_precision: 64,
@@ -655,7 +655,7 @@ describe('cockroachdb-no-search-path', () => {
         {
           name: 'created_at',
           table: 'teams',
-          data_type: 'timestamp',
+          data_type: 'timestamp without time zone',
           default_value: null,
           max_length: null,
           numeric_precision: null,
@@ -700,7 +700,7 @@ describe('cockroachdb-no-search-path', () => {
         schema: 'public',
         name: 'uuid',
         table: 'teams',
-        data_type: 'bpchar',
+        data_type: 'character',
         default_value: null,
         max_length: 36,
         numeric_precision: null,

--- a/test/cockroachdb.spec.ts
+++ b/test/cockroachdb.spec.ts
@@ -130,7 +130,7 @@ describe('cockroachdb-no-search-path', () => {
         {
           name: 'primaryKey',
           table: 'camelCase',
-          data_type: 'bigint',
+          data_type: 'int8',
           default_value: 'unique_rowid()',
           max_length: null,
           numeric_precision: 64,
@@ -149,7 +149,7 @@ describe('cockroachdb-no-search-path', () => {
         },
         {
           comment: null,
-          data_type: 'bigint',
+          data_type: 'int8',
           default_value: 'unique_rowid()',
           foreign_key_column: null,
           foreign_key_schema: null,
@@ -169,7 +169,7 @@ describe('cockroachdb-no-search-path', () => {
         },
         {
           comment: null,
-          data_type: 'bigint',
+          data_type: 'int8',
           default_value: null,
           foreign_key_column: 'primaryKey',
           foreign_key_schema: 'public',
@@ -189,7 +189,7 @@ describe('cockroachdb-no-search-path', () => {
         },
         {
           comment: null,
-          data_type: 'bigint',
+          data_type: 'int8',
           default_value: null,
           foreign_key_column: 'id',
           foreign_key_schema: 'public',
@@ -250,7 +250,7 @@ describe('cockroachdb-no-search-path', () => {
         {
           name: 'created_at',
           table: 'page_visits',
-          data_type: 'timestamp without time zone',
+          data_type: 'timestamp',
           default_value: null,
           max_length: null,
           numeric_precision: null,
@@ -270,7 +270,7 @@ describe('cockroachdb-no-search-path', () => {
         {
           name: 'id',
           table: 'teams',
-          data_type: 'bigint',
+          data_type: 'int8',
           default_value: 'unique_rowid()',
           max_length: null,
           numeric_precision: 64,
@@ -290,7 +290,7 @@ describe('cockroachdb-no-search-path', () => {
         {
           name: 'uuid',
           table: 'teams',
-          data_type: 'character',
+          data_type: 'bpchar',
           default_value: null,
           max_length: 36,
           numeric_precision: null,
@@ -370,7 +370,7 @@ describe('cockroachdb-no-search-path', () => {
         {
           name: 'credits',
           table: 'teams',
-          data_type: 'bigint',
+          data_type: 'int8',
           default_value: null,
           max_length: null,
           numeric_precision: 64,
@@ -390,7 +390,7 @@ describe('cockroachdb-no-search-path', () => {
         {
           name: 'created_at',
           table: 'teams',
-          data_type: 'timestamp without time zone',
+          data_type: 'timestamp',
           default_value: null,
           max_length: null,
           numeric_precision: null,
@@ -430,7 +430,7 @@ describe('cockroachdb-no-search-path', () => {
         {
           name: 'id',
           table: 'users',
-          data_type: 'bigint',
+          data_type: 'int8',
           default_value: 'unique_rowid()',
           max_length: null,
           numeric_precision: 64,
@@ -450,7 +450,7 @@ describe('cockroachdb-no-search-path', () => {
         {
           name: 'team_id',
           table: 'users',
-          data_type: 'bigint',
+          data_type: 'int8',
           default_value: null,
           max_length: null,
           numeric_precision: 64,
@@ -535,7 +535,7 @@ describe('cockroachdb-no-search-path', () => {
         {
           name: 'id',
           table: 'teams',
-          data_type: 'bigint',
+          data_type: 'int8',
           default_value: 'unique_rowid()',
           max_length: null,
           numeric_precision: 64,
@@ -555,7 +555,7 @@ describe('cockroachdb-no-search-path', () => {
         {
           name: 'uuid',
           table: 'teams',
-          data_type: 'character',
+          data_type: 'bpchar',
           default_value: null,
           max_length: 36,
           numeric_precision: null,
@@ -575,7 +575,7 @@ describe('cockroachdb-no-search-path', () => {
         {
           name: 'name',
           table: 'teams',
-          data_type: 'character varying',
+          data_type: 'varchar',
           default_value: null,
           max_length: 100,
           numeric_precision: null,
@@ -595,12 +595,12 @@ describe('cockroachdb-no-search-path', () => {
         {
           name: 'name_upper',
           table: 'teams',
-          data_type: 'character varying',
+          data_type: 'varchar',
           default_value: null,
           max_length: 100,
           numeric_precision: null,
           numeric_scale: null,
-          is_generated: false,
+          is_generated: true,
           generation_expression: 'upper(name)',
           is_nullable: true,
           is_unique: false,
@@ -635,7 +635,7 @@ describe('cockroachdb-no-search-path', () => {
         {
           name: 'credits',
           table: 'teams',
-          data_type: 'bigint',
+          data_type: 'int8',
           default_value: null,
           max_length: null,
           numeric_precision: 64,
@@ -655,7 +655,7 @@ describe('cockroachdb-no-search-path', () => {
         {
           name: 'created_at',
           table: 'teams',
-          data_type: 'timestamp without time zone',
+          data_type: 'timestamp',
           default_value: null,
           max_length: null,
           numeric_precision: null,
@@ -700,7 +700,7 @@ describe('cockroachdb-no-search-path', () => {
         schema: 'public',
         name: 'uuid',
         table: 'teams',
-        data_type: 'character',
+        data_type: 'bpchar',
         default_value: null,
         max_length: 36,
         numeric_precision: null,

--- a/test/postgres.spec.ts
+++ b/test/postgres.spec.ts
@@ -42,14 +42,14 @@ describe('postgres-no-search-path', () => {
       expect(await inspector.tableInfo()).to.have.deep.members([
         { name: 'camelCase', schema: 'public', comment: null },
         { name: 'page_visits', schema: 'public', comment: null },
-        { name: 'teams', schema: 'public', comment: null },
+        { name: 'teams', schema: 'public', comment: 'Teams in competition' },
         { name: 'users', schema: 'public', comment: null },
       ]);
     });
 
     it('returns information for specific table', async () => {
       expect(await inspector.tableInfo('teams')).to.deep.equal({
-        comment: null,
+        comment: 'Teams in competition',
         name: 'teams',
         schema: 'public',
       });

--- a/test/seed/cockroachdb.sql
+++ b/test/seed/cockroachdb.sql
@@ -10,6 +10,7 @@ create table teams (
   unique(uuid)
 );
 
+comment on table teams is 'Teams in competition';
 comment on column teams.credits is 'Remaining usage credits';
 
 create table users (

--- a/test/seed/postgres.sql
+++ b/test/seed/postgres.sql
@@ -10,6 +10,7 @@ create table teams (
   unique(uuid)
 );
 comment on column teams.credits is 'Remaining usage credits';
+COMMENT ON TABLE teams IS 'Teams in competition';
 
 create table users (
   id serial primary key,


### PR DESCRIPTION
Resolves performance regression in PG by relying on the faster pg_catalog tables (rather than the information_schema views).

Ideally, we do the same for the cockroach internal tables in a custom dialect, seeing cockroach has a similar performance penalty on pg_* tables.

Fixes directus/directus#11209