### PR TITLE
Strip quotes in MySQL dialect for MariaDB

### DIFF
--- a/lib/dialects/mysql.ts
+++ b/lib/dialects/mysql.ts
@@ -3,6 +3,7 @@ import { SchemaInspector } from '../types/schema-inspector';
 import { Table } from '../types/table';
 import { Column } from '../types/column';
 import { ForeignKey } from '../types/foreign-key';
+import { stripQuotes } from '../utils/strip-quotes';
 
 type RawTable = {
   TABLE_NAME: string;
@@ -63,7 +64,7 @@ export function rawColumnToColumn(rawColumn: RawColumn): Column {
 export function parseDefaultValue(value: string | null) {
   if (value === null || value.trim().toLowerCase() === 'null') return null;
 
-  return value;
+  return stripQuotes(value);
 }
 
 export default class MySQL implements SchemaInspector {


### PR DESCRIPTION
Potentially required if MariaDB returns string defaults with quotes.