### PR TITLE
Constrain mysql query to the same database schema

### DIFF
--- a/lib/dialects/mysql.ts
+++ b/lib/dialects/mysql.ts
@@ -303,6 +303,7 @@ export default class MySQL implements SchemaInspector {
         information_schema.referential_constraints AS rc
       JOIN information_schema.key_column_usage AS kcu ON
         rc.CONSTRAINT_NAME = kcu.CONSTRAINT_NAME
+        AND kcu.CONSTRAINT_SCHEMA = rc.CONSTRAINT_SCHEMA
       WHERE
         rc.CONSTRAINT_SCHEMA = ?;
     `,


### PR DESCRIPTION
When multiple databases exist on the same server this query does not constrain the JOIN to the same schema. 
This patch fixes that.

Fixes: https://github.com/directus/directus/issues/15038