### PR TITLE
Remove trailing space for CURRENT_TIMESTAMP default value in Oracle

### DIFF
--- a/lib/dialects/oracledb.ts
+++ b/lib/dialects/oracledb.ts
@@ -52,6 +52,7 @@ export function rawColumnToColumn(rawColumn: RawColumn): Column {
 
 export function parseDefaultValue(value: string | null): string | null {
   if (value === null || value.trim().toLowerCase() === 'null') return null;
+  if (value === 'CURRENT_TIMESTAMP ') return 'CURRENT_TIMESTAMP';
 
   return stripQuotes(value);
 }


### PR DESCRIPTION
When testing in Oracle, noticed that there is occasionally a trailing space in the default value where `CURRENT_TIMESTAMP` becomes `CURRENT_TIMESTAMP `.