### PR TITLE
Fix postgres hascolumn return value

### DIFF
--- a/lib/dialects/postgres.ts
+++ b/lib/dialects/postgres.ts
@@ -358,11 +358,10 @@ export default class Postgres implements SchemaInspector {
       (schemaName) => `${this.knex.raw('?', [schemaName])}::regnamespace`
     );
 
-    const result = await this.knex.raw(
+    const result = await this.knex.raw<{ rows: { count: number }[] }>(
       `
       SELECT
-        att.attname AS column,
-        rel.relname AS table
+        COUNT(*)::integer as count
       FROM
         pg_attribute att
         LEFT JOIN pg_class rel ON att.attrelid = rel.oid
@@ -377,7 +376,7 @@ export default class Postgres implements SchemaInspector {
       [table, column]
     );
 
-    return result.rows;
+    return !!(result && result.rows[0].count > 0);
   }
 
   /**

--- a/lib/dialects/postgres.ts
+++ b/lib/dialects/postgres.ts
@@ -353,7 +353,7 @@ export default class Postgres implements SchemaInspector {
   /**
    * Check if the given table contains the given column
    */
-  async hasColumn(table: string, column: string) {
+  async hasColumn(table: string, column: string): Promise<boolean> {
     const schemaIn = this.explodedSchema.map(
       (schemaName) => `${this.knex.raw('?', [schemaName])}::regnamespace`
     );


### PR DESCRIPTION
According to the type definitions the hasColumn should return a Promise with boolean

```
hasColumn(table: string, column: string): Promise<boolean>;
```

It seems that all other dialects have this implemented the right way and only hasColumn for PostgreSQL returned an empty array when it should return false and an array with an object when it should return true.

This PR fixes that.